### PR TITLE
TECH-178 Remove Licensing Guards from Necessities

### DIFF
--- a/apps/web/pages/settings/developer/api-keys.tsx
+++ b/apps/web/pages/settings/developer/api-keys.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
 import type { TApiKeys } from "@calcom/ee/api-keys/components/ApiKeyListItem";
-import LicenseRequired from "@calcom/ee/common/components/LicenseRequired";
 import ApiKeyDialogForm from "@calcom/features/ee/api-keys/components/ApiKeyDialogForm";
 import ApiKeyListItem from "@calcom/features/ee/api-keys/components/ApiKeyListItem";
 import { getLayout } from "@calcom/features/settings/layouts/SettingsLayout";
@@ -74,35 +73,33 @@ const ApiKeysView = () => {
         borderInShellHeader={true}
       />
 
-      <LicenseRequired>
-        <div>
-          {data?.length ? (
-            <>
-              <div className="border-subtle rounded-b-lg border border-t-0">
-                {data.map((apiKey, index) => (
-                  <ApiKeyListItem
-                    key={apiKey.id}
-                    apiKey={apiKey}
-                    lastItem={data.length === index + 1}
-                    onEditClick={() => {
-                      setApiKeyToEdit(apiKey);
-                      setApiKeyModal(true);
-                    }}
-                  />
-                ))}
-              </div>
-            </>
-          ) : (
-            <EmptyScreen
-              Icon="link"
-              headline={t("create_first_api_key")}
-              description={t("create_first_api_key_description", { appName: APP_NAME })}
-              className="rounded-b-lg rounded-t-none border-t-0"
-              buttonRaw={<NewApiKeyButton />}
-            />
-          )}
-        </div>
-      </LicenseRequired>
+      <div>
+        {data?.length ? (
+          <>
+            <div className="border-subtle rounded-b-lg border border-t-0">
+              {data.map((apiKey, index) => (
+                <ApiKeyListItem
+                  key={apiKey.id}
+                  apiKey={apiKey}
+                  lastItem={data.length === index + 1}
+                  onEditClick={() => {
+                    setApiKeyToEdit(apiKey);
+                    setApiKeyModal(true);
+                  }}
+                />
+              ))}
+            </div>
+          </>
+        ) : (
+          <EmptyScreen
+            Icon="link"
+            headline={t("create_first_api_key")}
+            description={t("create_first_api_key_description", { appName: APP_NAME })}
+            className="rounded-b-lg rounded-t-none border-t-0"
+            buttonRaw={<NewApiKeyButton />}
+          />
+        )}
+      </div>
 
       <Dialog open={apiKeyModal} onOpenChange={setApiKeyModal}>
         <DialogContent type="creation">

--- a/packages/features/ee/users/components/UnverifiedUsersTable.tsx
+++ b/packages/features/ee/users/components/UnverifiedUsersTable.tsx
@@ -20,8 +20,6 @@ import {
   TextField,
 } from "@calcom/ui";
 
-import { withLicenseRequired } from "../../common/components/LicenseRequired";
-
 const { Cell, ColumnTitle, Header, Row } = Table;
 
 const FETCH_LIMIT = 25;
@@ -167,4 +165,4 @@ function UsersTableBare() {
   );
 }
 
-export const UsersTable = withLicenseRequired(UsersTableBare);
+export const UsersTable = UsersTableBare;

--- a/packages/features/ee/users/components/UsersTable.tsx
+++ b/packages/features/ee/users/components/UsersTable.tsx
@@ -23,8 +23,6 @@ import {
   TextField,
 } from "@calcom/ui";
 
-import { withLicenseRequired } from "../../common/components/LicenseRequired";
-
 const { Cell, ColumnTitle, Header, Row } = Table;
 
 const FETCH_LIMIT = 25;
@@ -321,4 +319,4 @@ const DeleteUserDialog = ({
   );
 };
 
-export const UsersTable = withLicenseRequired(UsersTableBare);
+export const UsersTable = UsersTableBare;


### PR DESCRIPTION
Removing Licensing Guards from Mentor Activation, API key generation, and general user table

Applying these changes should allow you to - even in production - access those pages in the user settings page

